### PR TITLE
JBIDE-15877, JBIDE-15876

### DIFF
--- a/cordova/plugins/org.jboss.tools.aerogear.hybrid.android.core/plugin.xml
+++ b/cordova/plugins/org.jboss.tools.aerogear.hybrid.android.core/plugin.xml
@@ -7,7 +7,7 @@
             delegate="org.jboss.tools.aerogear.hybrid.android.core.adt.AndroidLaunchDelegate"
             id="org.jboss.tools.aerogear.hybrid.android.core.AndroidLaunchConfigurationType"
             modes="run"
-            name="Android">
+            name="Android Emulator">
       </launchConfigurationType>
    </extension>
    <extension

--- a/cordova/plugins/org.jboss.tools.aerogear.hybrid.android.ui/plugin.xml
+++ b/cordova/plugins/org.jboss.tools.aerogear.hybrid.android.ui/plugin.xml
@@ -61,4 +61,13 @@
           projectGenerator="org.jboss.tools.aerogear.hybrid.android.core.projectGenerator">
     </platformImage>
  </extension>
+   <extension
+         point="org.eclipse.debug.ui.launchConfigurationTypeImages">
+      <launchConfigurationTypeImage
+            icon="$nl$/icons/elcl16/android_icon.png"
+            configTypeID="org.jboss.tools.aerogear.hybrid.android.core.AndroidLaunchConfigurationType"
+            id="org.jboss.tools.aerogear.hybrid.android.ui.AndroidLaunchConfigurationTypeImage">
+      </launchConfigurationTypeImage>
+   </extension>
+ 
 </plugin>

--- a/cordova/plugins/org.jboss.tools.aerogear.hybrid.ios.ui/plugin.xml
+++ b/cordova/plugins/org.jboss.tools.aerogear.hybrid.ios.ui/plugin.xml
@@ -47,5 +47,12 @@
             projectGenerator="org.jboss.tools.aerogear.hybrid.ios.core.projectGenerator">
       </platformImage>
    </extension>
-
+   <extension
+         point="org.eclipse.debug.ui.launchConfigurationTypeImages">
+      <launchConfigurationTypeImage
+            icon="$nl$/icons/elcl16/ios_icon.png"
+            configTypeID="org.jboss.tools.aerogear.hybrid.ios.core.IOSSimulatorLaunchConfigType"
+            id="org.jboss.tools.aerogear.hybrid.ios.ui.IOSSimulatorLaunchConfigTypeImage">
+      </launchConfigurationTypeImage>
+   </extension>
 </plugin>


### PR DESCRIPTION
In Run Configurations, Android label should be more descriptive
Android and iOS missing icons in "run configurations" wizard
