### PR TITLE
[JBDS-3049] Aerogear feature installation from JBDS central fails

### DIFF
--- a/cordova/plugins/org.jboss.tools.aerogear.hybrid.core/META-INF/MANIFEST.MF
+++ b/cordova/plugins/org.jboss.tools.aerogear.hybrid.core/META-INF/MANIFEST.MF
@@ -20,7 +20,7 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.wst.jsdt.core;bundle-version="[1.1.0,2.0.0)",
  org.apache.httpcomponents.httpclient;bundle-version="[4.2.5,4.3.0)",
  org.apache.httpcomponents.httpcore;bundle-version="[4.2.5,4.3.0)",
- org.jboss.tools.jst.jsdt
+ org.jboss.tools.jst.jsdt;resolution:=optional;x-installation:=greedy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Bundle-ActivationPolicy: lazy
 Export-Package: com.github.zafarkhaja.semver;x-friends:="org.jboss.tools.aerogear.hybrid.ui,org.jboss.tools.aerogear.hybrid.ios.core",

--- a/cordova/plugins/org.jboss.tools.aerogear.hybrid.core/src/org/jboss/tools/aerogear/hybrid/core/internal/libraries/CordovaLibraryJsContainerInitializer.java
+++ b/cordova/plugins/org.jboss.tools.aerogear.hybrid.core/src/org/jboss/tools/aerogear/hybrid/core/internal/libraries/CordovaLibraryJsContainerInitializer.java
@@ -38,6 +38,7 @@ import org.jboss.tools.aerogear.hybrid.core.engine.HybridMobileLibraryResolver;
 import org.jboss.tools.aerogear.hybrid.core.engine.PlatformLibrary;
 import org.jboss.tools.aerogear.hybrid.core.platform.PlatformConstants;
 import org.jboss.tools.jst.jsdt.utils.ConfigUtils;
+import org.osgi.framework.Bundle;
 
 public class CordovaLibraryJsContainerInitializer extends JsGlobalScopeContainerInitializer {
 	
@@ -61,7 +62,10 @@ public class CordovaLibraryJsContainerInitializer extends JsGlobalScopeContainer
 		CordovaLibraryJsContainerInitializer scopeContainer = new CordovaLibraryJsContainerInitializer(project);
 		JavaScriptCore.setJsGlobalScopeContainer(containerPath, new IJavaScriptProject[] { project }, new IJsGlobalScopeContainer[] {scopeContainer} , null);
 		try {
-			ConfigUtils.enableCordovaJSPlugin(project.getProject());
+			Bundle optBundle = Platform.getBundle("org.jboss.tools.jst.jsdt");
+			if(optBundle!=null && optBundle.getState()==Bundle.RESOLVED) {
+				CordovaPluginConfigurator.enableCordovaJSPlugin(project.getProject());
+			}
 		} catch (IOException e) {
 			HybridCore.log(IStatus.ERROR, "Error configuring the Cordova library plugin for Content Assist", e);	
 		}

--- a/cordova/plugins/org.jboss.tools.aerogear.hybrid.core/src/org/jboss/tools/aerogear/hybrid/core/internal/libraries/CordovaPluginConfigurator.java
+++ b/cordova/plugins/org.jboss.tools.aerogear.hybrid.core/src/org/jboss/tools/aerogear/hybrid/core/internal/libraries/CordovaPluginConfigurator.java
@@ -1,0 +1,13 @@
+package org.jboss.tools.aerogear.hybrid.core.internal.libraries;
+
+import java.io.IOException;
+
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.runtime.CoreException;
+
+public class CordovaPluginConfigurator {
+
+	public static void enableCordovaJSPlugin(IProject project) throws CoreException, IOException {
+		org.jboss.tools.jst.jsdt.utils.ConfigUtils.enableCordovaJSPlugin(project);
+	}
+}


### PR DESCRIPTION
this fix makes jst.jsdt optional for HMT and tern cordoavjs plugin only gets
enabled when tern bundles are available.
