### PR TITLE
JBIDE-18692 CordovaSim: Changing the output dir from 'ripple' to the plu...

### DIFF
--- a/cordovasim/plugins/org.jboss.tools.vpe.cordovasim.ripple/.gitignore
+++ b/cordovasim/plugins/org.jboss.tools.vpe.cordovasim.ripple/.gitignore
@@ -1,1 +1,1 @@
-ripple 
+ripple/

--- a/cordovasim/plugins/org.jboss.tools.vpe.cordovasim.ripple/pom.xml
+++ b/cordovasim/plugins/org.jboss.tools.vpe.cordovasim.ripple/pom.xml
@@ -45,7 +45,7 @@
 									<artifactId>ripple</artifactId>
 									<version>${rippleVersion}</version>
 									<type>zip</type>
-									<outputDirectory>${basedir}/ripple</outputDirectory>
+									<outputDirectory>${basedir}</outputDirectory>
 								</artifact>
 							</artifactItems>
 						</configuration>


### PR DESCRIPTION
Assuming that [incubator-ripple](https://github.com/jbosstools/incubator-ripple/commit/95d0c9772a579476391bb0068b31012425db174b) already pack all files to the 'ripple' folder, during the cordovasim.ripple plugin build the zip should be unpacked to the root folder (otherwise the file structure will be the following ripple/ripple/all_other_files).
@dgolovin could you +1 to apply