### PR TITLE
JBIDE-22258: Bump to new thym build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
     <properties>
         <tycho.scmUrl>scm:git:https://github.com/jbosstools/jbosstools-aerogear.git</tycho.scmUrl>
         <thym.reqs.url>http://download.jboss.org/jbosstools/updates/requirements/thym</thym.reqs.url>
-        <thym.version>2.0.0-SNAPSHOT-201603211426</thym.version>
+        <thym.version>2.0.0-SNAPSHOT-201605071736</thym.version>
     </properties>
     <modules>
         <module>cordova</module>


### PR DESCRIPTION
This removes dependency to deprecated org.eclipse.e4.ui.importer