### PR TITLE
JBIDE-22881 fixes for enforcement problems, and upgrade to latest thym 2.0.0 snapshot

### DIFF
--- a/cordovasim/plugins/org.jboss.tools.cordovasim.ripple/pom.xml
+++ b/cordovasim/plugins/org.jboss.tools.cordovasim.ripple/pom.xml
@@ -12,6 +12,8 @@
 	
 	<properties>
 		<rippleVersion>4.3.0-SNAPSHOT</rippleVersion>
+		<!-- add properties which we'll ignore from the snapshot enforcer rule; note: must start with a pipe (|) so these are appended as OR matches -->
+		<enforceExcludePatternExtras>|rippleVersion</enforceExcludePatternExtras>
 	</properties>
 	
 	<build>

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
     <properties>
         <tycho.scmUrl>scm:git:https://github.com/jbosstools/jbosstools-aerogear.git</tycho.scmUrl>
         <thym.reqs.url>http://download.jboss.org/jbosstools/updates/requirements/thym</thym.reqs.url>
-        <thym.version>2.0.0-SNAPSHOT-201605071736</thym.version>
+        <thym.version>2.0.0.201607041526</thym.version>
     </properties>
     <modules>
         <module>cordova</module>

--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,8 @@
         <tycho.scmUrl>scm:git:https://github.com/jbosstools/jbosstools-aerogear.git</tycho.scmUrl>
         <thym.reqs.url>http://download.jboss.org/jbosstools/updates/requirements/thym</thym.reqs.url>
         <thym.version>2.0.0.201607041526</thym.version>
+        <!-- add properties which we'll ignore from the snapshot enforcer rule; note: must start with a pipe (|) so these are appended as OR matches -->
+        <enforceExcludePatternExtras>|thym.version</enforceExcludePatternExtras>
     </properties>
     <modules>
         <module>cordova</module>


### PR DESCRIPTION
* JBIDE-22881 switch from old 2.0.0-SNAPSHOT-201605071736 to latest snapshot 2.0.0.201607041526

* add enforceExcludePatternExtras = |rippleVersion or |thym.version so we're reminded that these ought to be non-SNAPSHOT versions. Not as good as enforcement, but at least it's documented (JBIDE-22881)